### PR TITLE
Autodetect COQBIN in tests/Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,7 @@
+ifeq "$(COQBIN)" ""
+  COQBIN=$(dir $(shell which coqtop))/
+endif
+
 all: $(patsubst %.v,%.v.log,$(wildcard *.v))
 
 %.v.log: %.v


### PR DESCRIPTION
The top-level Makefile automatically uses `which coqtop` to detect where Coq is installed, allowing the user to forget to set COQBIN.

This PR copies this feature to `tests/Makefile`, allowing the user who has successfully built Ltac2 without setting COQBIN to also run the tests.