### PR TITLE
Remove VtUnknown classification

### DIFF
--- a/src/g_ltac2.mlg
+++ b/src/g_ltac2.mlg
@@ -884,7 +884,7 @@ END
 {
 
 let classify_ltac2 = function
-| StrSyn _ -> Vernacextend.(VtUnknown, VtNow)
+| StrSyn _ -> Vernacextend.(VtSideff [], VtNow)
 | StrMut _ | StrVal _ | StrPrm _  | StrTyp _ | StrRun _ -> Vernacextend.classify_as_sideeff
 
 }


### PR DESCRIPTION
That classification is going to disappear from Coq. However, I don't
understand why it was used here. Can you confirm that the command can
not open a proof?

This is necessary for https://github.com/coq/coq/pull/9530